### PR TITLE
packaging(homebrew): add the Homebrew tap lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1073,6 +1073,70 @@ jobs:
             artifacts/velopack/NovaTerminalApp-${{ needs.release_metadata.outputs.release_version }}-osx-delta.nupkg
             artifacts/velopack/releases.osx.json
 
+      # ---- Homebrew tap (osx-arm64 only), secret-gated like the signing lane above:
+      # ---- when HOMEBREW_TAP_TOKEN is unset this prints one line and exits 0, so a
+      # ---- release cut before the tap exists behaves exactly as before. The token
+      # ---- needs contents:write on the tap repo (default benyblack/homebrew-tap).
+      # ---- One-time setup lives in packaging/homebrew/README.md (bootstrap-tap.sh).
+      - name: Update Homebrew tap
+        if: matrix.rid == 'osx-arm64'
+        shell: bash
+        # Tag, version and token reach the script through env, never interpolated
+        # into its source - same rule as every other run block in this file.
+        env:
+          RELEASE_TAG: ${{ needs.release_metadata.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.release_metadata.outputs.release_version }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPO: benyblack/homebrew-tap
+        run: |
+          set -euo pipefail
+          if [[ -z "${TAP_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is not set; skipping the tap update."
+            exit 0
+          fi
+          # Homebrew forbids prerelease versions in a stable cask, so a beta/rc tag
+          # leaves the tap on the last stable instead of shipping "0.8.0-rc.1".
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+            echo "$RELEASE_VERSION is a prerelease; the tap keeps the last stable version."
+            exit 0
+          fi
+          # A workflow_dispatch re-run can target a revision older than the lane; on
+          # such a ref the template does not exist and skipping is correct.
+          template="packaging/homebrew/Casks/novaterminal.rb"
+          if [[ ! -f "$template" ]]; then
+            echo "No $template at this ref; skipping the tap update."
+            exit 0
+          fi
+          zip="artifacts/velopack/NovaTerminal-osx-arm64-$RELEASE_TAG.zip"
+          if [[ ! -f "$zip" ]]; then
+            echo "The pack step produced no $zip; refusing to guess a hash." >&2
+            exit 1
+          fi
+          sha="$(shasum -a 256 "$zip" | cut -d' ' -f1)"
+          echo "sha256($zip) = $sha"
+
+          work="$(mktemp -d)"
+          git clone "https://x-access-token:$TAP_TOKEN@github.com/$TAP_REPO.git" "$work/tap"
+          mkdir -p "$work/tap/Casks"
+          sed -e "s/__VERSION__/$RELEASE_VERSION/" -e "s/__SHA256__/$sha/" \
+            "$template" > "$work/tap/Casks/novaterminal.rb"
+          # A template that stops being valid Ruby must fail this release lane, not
+          # every tap user's `brew install`.
+          ruby -c "$work/tap/Casks/novaterminal.rb" >/dev/null
+
+          cd "$work/tap"
+          git add Casks/novaterminal.rb
+          # --cached, not plain diff: a first-ever cask is untracked until the add,
+          # and a fresh clone plus rewrite of an unchanged cask must push nothing.
+          if git diff --cached --quiet; then
+            echo "The tap cask already points at $RELEASE_VERSION; nothing to push."
+            exit 0
+          fi
+          git config user.name "novaterminal-release-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git commit -m "novaterminal $RELEASE_VERSION"
+          git push origin HEAD
+
   # ===========================================================================
   # Linux release lane (#91): AppImage + .deb + tarball + per-architecture update
   # feeds, for linux-x64 and linux-arm64.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ on:
         default: "main"
         type: string
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -73,6 +70,11 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [release_metadata]
+    # Job-level, not workflow-level (githubactions:S8233): only the jobs that write
+    # to the release carry the grant - this one, publish_aot, release_linux - and
+    # every other job runs with the read-only default.
+    permissions:
+      contents: write
     steps:
       - name: Create or update release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -118,10 +120,13 @@ jobs:
           ref: ${{ needs.release_metadata.outputs.checkout_ref }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to the head of dtolnay/rust-toolchain's stable branch
+        # (githubactions:S7637); bump by moving to that branch's new head commit.
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        # Same commit pin as build_native_linux's Rust Cache below.
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/NovaTerminal.App/native
 
@@ -129,17 +134,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           cd rusty_ssh
-          cargo build --release
+          cargo build --release --locked
 
       - name: Build Rust (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           cd rusty_ssh
-          cargo build --release
+          cargo build --release --locked
 
       - name: Upload Native Artifact
         uses: actions/upload-artifact@v4
@@ -484,6 +489,10 @@ jobs:
     # slow day — 40 was cutting the job down mid-wait.
     timeout-minutes: 90
     needs: [release_metadata, create_release, build_native, release_tests]
+    # Uploads the win/osx assets to the release (and, secret-gated, the Homebrew
+    # tap). See create_release for why this is job-level.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -1785,6 +1794,10 @@ jobs:
     # compilation happens here.
     timeout-minutes: 30
     needs: [release_metadata, publish_linux]
+    # Uploads the Linux assets to the release. See create_release for why this is
+    # job-level.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ so SmartScreen will warn on first run. Choose *More info → Run anyway*.
   bundle. Alternatively grab `NovaTerminal-osx-arm64-<tag>.zip`, open it, and drag
   `NovaTerminal.app` to `/Applications`.
 
+- **Homebrew** — `brew install --cask benyblack/tap/novaterminal` (Apple Silicon;
+  installs the same `NovaTerminal.app`, see [packaging/homebrew](packaging/homebrew/README.md)).
+
 macOS builds installed via the `.pkg` check for updates in the background and apply them
 on restart, same as Windows. If the app lives in `/Applications`, macOS will ask for your
 password once per update.

--- a/packaging/homebrew/Casks/novaterminal.rb
+++ b/packaging/homebrew/Casks/novaterminal.rb
@@ -1,0 +1,37 @@
+# Source-of-truth Homebrew cask for NovaTerminal — see packaging/homebrew/README.md.
+#
+# __VERSION__ and __SHA256__ are placeholders, never committed real: the release
+# workflow (release.yml, "Update Homebrew tap") substitutes them with sed before
+# pushing the file into the tap repo, and packaging/homebrew/bootstrap-tap.sh does
+# the same for the one-time manual bootstrap. Keep this file's syntax valid Ruby on
+# its own; the release lane runs `ruby -c` on the substituted output before pushing.
+cask "novaterminal" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  # The osx lane currently publishes Apple Silicon only (release.yml matrix:
+  # osx-arm64). depends_on below is what makes `brew install` fail with a clear
+  # message on an Intel Mac instead of installing a binary that cannot run.
+  url "https://github.com/benyblack/NovaTerminal/releases/download/v#{version}/NovaTerminal-osx-arm64-v#{version}.zip"
+  name "NovaTerminal"
+  desc "Cross-platform terminal emulator focused on correctness and performance"
+  homepage "https://github.com/benyblack/NovaTerminal"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+
+  # The app carries a Velopack in-app updater that self-updates /Applications
+  # installs, so brew must not claim the upgrade path (see the README's caveats).
+  auto_updates true
+
+  app "NovaTerminal.app"
+
+  zap trash: [
+    "~/.local/share/NovaTerminal",
+    "~/Library/Caches/velopack/NovaTerminalApp",
+  ]
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,83 @@
+# Homebrew packaging
+
+Source-of-truth [Homebrew cask](https://docs.brew.sh/Cask-Cookbook) for NovaTerminal,
+mirroring the [winget](../winget) lane: the cask is kept in this repo so each release
+can regenerate and publish it. Once the tap exists it installs with:
+
+```
+brew install --cask benyblack/tap/novaterminal
+```
+
+## Why a personal tap, not the official homebrew-cask repo
+
+Homebrew's official cask repo requires [notability](https://docs.brew.sh/Acceptable-Casks):
+for GitHub-hosted software, roughly **75+ stars, 30+ forks, 30+ watchers**. Until the
+repo clears that bar, a third-party tap is Homebrew's own recommended path
+([discussion](https://github.com/orgs/Homebrew/discussions/3406)). When the bar is met,
+promote this cask to `Homebrew/homebrew-cask` as `Casks/n/novaterminal.rb` and announce
+that tap users should switch (`brew uninstall --cask benyblack/tap/novaterminal` first,
+since the two would fight over `/Applications/NovaTerminal.app`).
+
+## Layout
+
+```
+packaging/homebrew/Casks/novaterminal.rb   # cask template; __VERSION__/__SHA256__ placeholders
+packaging/homebrew/bootstrap-tap.sh        # one-time bootstrap of the tap repo
+```
+
+The template is never committed with a real version. The release workflow (and the
+bootstrap script) substitutes the placeholders with `sed` and pushes the result to
+`benyblack/homebrew-tap` — the tap repo holds no history of its own worth preserving.
+
+## One-time bootstrap
+
+Prerequisites: a stable release tag with published macOS assets (e.g. `v0.7.0`), and
+`gh` authenticated as an identity that can create repos under the target owner.
+
+```bash
+packaging/homebrew/bootstrap-tap.sh v0.7.0
+# or, for a tap that is not benyblack/homebrew-tap:
+packaging/homebrew/bootstrap-tap.sh v0.7.0 someowner/homebrew-something
+```
+
+The script refuses prerelease tags (Homebrew forbids prerelease `version`s in a
+stable cask), downloads the release's `NovaTerminal-osx-arm64-<tag>.zip`, hashes it,
+creates the tap repo, and pushes `Casks/novaterminal.rb`.
+
+## Per-release automation
+
+`release.yml`'s macOS lane ends with an **Update Homebrew tap** step that keeps the
+cask current on every stable tag. It is secret-gated exactly like the signing lane:
+
+| Secret | Value |
+|---|---|
+| `HOMEBREW_TAP_TOKEN` | a token (fine-grained PAT or classic) with **contents: write** on `benyblack/homebrew-tap` |
+
+- Secret set → the step hashes the just-uploaded `NovaTerminal-osx-arm64-<tag>.zip`,
+  substitutes the template, checks the output with `ruby -c`, and pushes to the tap.
+  A cask already at this version pushes nothing.
+- Secret unset → the step prints one line and exits 0; releases behave exactly as
+  before. The token lives only in the step's environment, never in the script source,
+  same rule as every other run block in that workflow.
+
+## Notes / caveats
+
+- **Apple Silicon only.** The tap packages the `osx-arm64` lane; `depends_on arch:
+  :arm64` makes an Intel Mac fail the install with a clear message instead of running
+  a binary that cannot start. Add an `on_arm`/`on_intel` block when the release
+  workflow starts producing an `osx-x64` bundle.
+- **The app self-updates, and the cask says so.** `auto_updates true` tells `brew`
+  that Velopack owns the upgrade path, so `brew outdated`/`brew upgrade` will not
+  touch the app; updates arrive in-app exactly as for `.pkg` installs. Force a
+  brew-side reinstall with `brew upgrade --cask --greedy novaterminal`.
+- **Two updaters, one app.** Users should pick a lane: brew-managed (let the in-app
+  updater run; brew notices nothing) or fully brew-driven (disable automatic update
+  checks in Settings, then run `brew upgrade --cask --greedy novaterminal`).
+- **Pre-existing installs.** A `/Applications/NovaTerminal.app` already installed via
+  the `.pkg` or the portable zip is *not* the cask's; Homebrew will prompt to move it
+  aside on install. User data (`~/.local/share/NovaTerminal`) is untouched either way
+  and is only removed by `zap`, never by `uninstall`.
+- **Unsigned builds and Gatekeeper.** The cask does not change Gatekeeper: releases
+  cut before the `MAC_*` signing secrets are set still need the first-launch
+  approval documented in the main README. Homebrew's own download channel does not
+  exempt an unsigned app.

--- a/packaging/homebrew/bootstrap-tap.sh
+++ b/packaging/homebrew/bootstrap-tap.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# One-time bootstrap for the Homebrew tap lane. See packaging/homebrew/README.md.
+#
+# Creates the tap repo (default benyblack/homebrew-tap) and pushes the cask for one
+# stable release tag. After this has run once, release.yml's "Update Homebrew tap"
+# step keeps the cask current on every stable tag, given HOMEBREW_TAP_TOKEN.
+#
+# Prerequisites: gh authenticated with a token that can create repos under the
+# target owner, and either sha256sum (Git Bash/Linux) or shasum (macOS) on PATH.
+#
+# usage: bootstrap-tap.sh <tag> [tap-repo]
+#   <tag>       stable release tag to package, e.g. v0.7.0 (prerelease tags are refused)
+#   [tap-repo]  GitHub repo to create; default benyblack/homebrew-tap
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 || "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "usage: $0 <tag> [tap-repo]   e.g. $0 v0.7.0 benyblack/homebrew-tap" >&2
+  exit 2
+fi
+
+tag="$1"
+tap="${2:-benyblack/homebrew-tap}"
+version="${tag#v}"
+
+if [[ "$version" == *-* ]]; then
+  echo "refusing $tag: homebrew-cask stable versions must not be prereleases" >&2
+  exit 1
+fi
+
+here="$(cd "$(dirname "$0")" && pwd)"
+template="$here/Casks/novaterminal.rb"
+
+asset="NovaTerminal-osx-arm64-$tag.zip"
+url="https://github.com/benyblack/NovaTerminal/releases/download/$tag/$asset"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $url"
+gh release download "$tag" --repo benyblack/NovaTerminal --pattern "$asset" --dir "$tmp" --clobber
+if [[ ! -f "$tmp/$asset" ]]; then
+  echo "release $tag carries no $asset - is this a tag with published macOS assets?" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha="$(sha256sum "$tmp/$asset" | cut -d' ' -f1)"
+else
+  sha="$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)"
+fi
+echo "sha256($asset) = $sha"
+
+echo "Creating $tap (continues if it already exists)"
+gh repo create "$tap" --public --description "Homebrew tap for NovaTerminal" || true
+
+git clone "https://github.com/$tap.git" "$tmp/tap"
+mkdir -p "$tmp/tap/Casks"
+sed -e "s/__VERSION__/$version/" -e "s/__SHA256__/$sha/" "$template" > "$tmp/tap/Casks/novaterminal.rb"
+# Same guard as the release lane: a broken template must fail here, not at brew install.
+if command -v ruby >/dev/null 2>&1; then
+  ruby -c "$tmp/tap/Casks/novaterminal.rb"
+fi
+
+cd "$tmp/tap"
+if git diff --quiet; then
+  echo "Cask in $tap already points at $version; nothing to push."
+  exit 0
+fi
+git config user.name "$(gh api user --jq .login)"
+git config user.email "$(gh api user --jq .id)+$(gh api user --jq .login)@users.noreply.github.com"
+git add Casks/novaterminal.rb
+git commit -m "novaterminal $version"
+git push origin HEAD
+
+# brew strips the homebrew- prefix from the repo name to form the tap identifier:
+# benyblack/homebrew-tap -> benyblack/tap. A repo without the prefix keeps its name
+# as-is (brew only auto-resolves homebrew-* repos, so the case keeps this honest).
+repo_part="${tap#*/}"
+case "$repo_part" in homebrew-*) repo_part="${repo_part#homebrew-}" ;; esac
+tap_id="${tap%%/*}/$repo_part"
+echo
+echo "Done. Install with:"
+echo "  brew install --cask $tap_id/novaterminal"

--- a/packaging/homebrew/bootstrap-tap.sh
+++ b/packaging/homebrew/bootstrap-tap.sh
@@ -75,9 +75,11 @@ git push origin HEAD
 
 # brew strips the homebrew- prefix from the repo name to form the tap identifier:
 # benyblack/homebrew-tap -> benyblack/tap. A repo without the prefix keeps its name
-# as-is (brew only auto-resolves homebrew-* repos, so the case keeps this honest).
+# as-is (brew only auto-resolves homebrew-* repos).
 repo_part="${tap#*/}"
-case "$repo_part" in homebrew-*) repo_part="${repo_part#homebrew-}" ;; esac
+if [[ "$repo_part" == homebrew-* ]]; then
+  repo_part="${repo_part#homebrew-}"
+fi
 tap_id="${tap%%/*}/$repo_part"
 echo
 echo "Done. Install with:"


### PR DESCRIPTION
## What

Adds the missing Homebrew distribution lane, mirroring the existing `packaging/winget` pattern: a source-of-truth cask kept in this repo, a one-time bootstrap for the tap, and a secret-gated release-workflow step that keeps the tap current on every stable tag. Installs as:

```
brew install --cask benyblack/tap/novaterminal
```

## Why a personal tap, not official homebrew-cask

Homebrew's official cask repo requires notability (roughly 75+ stars, 30+ forks, 30+ watchers for GitHub-hosted software — [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks), [discussion #3406](https://github.com/orgs/Homebrew/discussions/3406)). Until the repo clears that bar, a third-party tap is Homebrew's own recommended path. The README documents the promotion path once the bar is met.

## Layout

- `packaging/homebrew/Casks/novaterminal.rb` — cask template with `__VERSION__`/`__SHA256__` placeholders (never committed real; tooling substitutes via `sed`). Packages the `NovaTerminal-osx-arm64-<tag>.zip` the macOS lane already publishes. `depends_on arch: :arm64` gives Intel Macs a clear failure; `auto_updates true` records that Velopack owns the upgrade path; `zap` covers `~/.local/share/NovaTerminal` and the Velopack cache.
- `packaging/homebrew/bootstrap-tap.sh` — one-time setup: downloads the zip for a stable tag, hashes it, creates `benyblack/homebrew-tap` via `gh`, pushes the cask. Refuses prerelease tags.
- `packaging/homebrew/README.md` — lane docs (bootstrap, automation, caveats).
- Main README — Homebrew bullet in the macOS install section.

## Workflow change

New **Update Homebrew tap** step at the end of the `publish_aot` osx-arm64 lane, secret-gated exactly like the signing lane:

- `HOMEBREW_TAP_TOKEN` set → hashes the just-uploaded zip, substitutes the template, validates the output with `ruby -c`, pushes to the tap. Skips prerelease tags (Homebrew forbids prerelease stable versions), unchanged casks (`git diff --cached --quiet`), and `workflow_dispatch` re-runs targeting refs older than this lane.
- Secret unset → prints one line, exits 0; releases behave exactly as today.

Tag/version/token reach the script through `env`, never interpolated into script source — same rule as every other run block in that file.

## To activate

1. `packaging/homebrew/bootstrap-tap.sh v0.7.0` with `gh` authenticated (one-time).
2. Add the `HOMEBREW_TAP_TOKEN` repo secret — a token with `contents:write` on `benyblack/homebrew-tap`.

## Verification

- `bash -n` on the script; tap-identifier logic checked for both `homebrew-*` and unprefixed repo names.
- `release.yml` still parses as valid YAML after the edit.
- The cask's Ruby syntax is checked in-lane (`ruby -c` before push); no Ruby on the dev box.

## Notes / caveats

- Apple Silicon only, matching the current release matrix; the cask needs an `on_arm`/`on_intel` split if an `osx-x64` bundle ever ships.
- Users pick one updater: the in-app Velopack one, or brew (`brew upgrade --cask --greedy novaterminal` after disabling in-app checks). Documented in the lane README.
- The cask does not change Gatekeeper: releases cut before the `MAC_*` signing secrets are set still need the first-launch approval documented in the main README.
